### PR TITLE
Feat content 상세 조회 API

### DIFF
--- a/src/main/java/com/subcrii/subcrii/domain/content/controller/ContentController.java
+++ b/src/main/java/com/subcrii/subcrii/domain/content/controller/ContentController.java
@@ -1,5 +1,6 @@
 package com.subcrii.subcrii.domain.content.controller;
 
+import com.subcrii.subcrii.domain.content.dto.ContentDetailResponse;
 import com.subcrii.subcrii.domain.content.dto.ContentListResponse;
 import com.subcrii.subcrii.domain.content.service.ContentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,5 +29,15 @@ public class ContentController {
     ) {
         Page<ContentListResponse> contentListResponses = contentService.getContentList(creatorId, pageable);
         return ResponseEntity.ok(contentListResponses);
+    }
+
+    @GetMapping("/{creatorId}/contents/{contentId}")
+    @Operation(summary = "컨텐츠 상세 조회", description = "구독한 크리에이터의 컨텐츠 내용을 조회할 수 있습니다.")
+    public ResponseEntity<ContentDetailResponse> getContentDetail(
+            @PathVariable UUID creatorId,
+            @PathVariable UUID contentId
+    ) {
+        ContentDetailResponse contentDetailResponse = contentService.getContentDetail(creatorId, contentId);
+        return ResponseEntity.ok(contentDetailResponse);
     }
 }

--- a/src/main/java/com/subcrii/subcrii/domain/content/dto/ContentDetailResponse.java
+++ b/src/main/java/com/subcrii/subcrii/domain/content/dto/ContentDetailResponse.java
@@ -1,0 +1,19 @@
+package com.subcrii.subcrii.domain.content.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class ContentDetailResponse {
+    private UUID id;
+    private UUID creatorId;
+    private String creatorNickName;
+    private String categoryName;
+    private String title;
+    private String description;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/subcrii/subcrii/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/subcrii/subcrii/domain/content/repository/ContentRepository.java
@@ -1,12 +1,15 @@
 package com.subcrii.subcrii.domain.content.repository;
 
+import com.subcrii.subcrii.domain.content.dto.ContentDetailResponse;
 import com.subcrii.subcrii.domain.content.dto.ContentListResponse;
 import com.subcrii.subcrii.domain.content.entity.Content;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface ContentRepository extends JpaRepository<Content, UUID> {
@@ -23,12 +26,30 @@ public interface ContentRepository extends JpaRepository<Content, UUID> {
                 from Content c
                 join c.creator cr
                 join cr.category cat
-                where cr.id = :creatorId
+                where c.creator.id = :creatorId
                 order by c.createdAt desc
             """, countQuery = """
               select count(c)
               from Content c
               where c.creator.id = :creatorId
             """)
-    Page<ContentListResponse> findContentListByCreatorId(UUID creatorId, Pageable pageable);
+    Page<ContentListResponse> findContentListByCreatorId(@Param("creatorId") UUID creatorId, Pageable pageable);
+
+    @Query("""
+            select new com.subcrii.subcrii.domain.content.dto.ContentDetailResponse(
+                c.id,
+                cr.id,
+                cr.nickName,
+                cat.name,
+                c.title,
+                c.description,
+                c.createdAt
+            )
+            from Content c
+            join c.creator cr
+            join cr.category cat
+            where c.id = :contentId
+            and c.creator.id = :creatorId
+            """)
+    Optional<ContentDetailResponse> findDetailByCreatorIdAndContentId(@Param("creatorId") UUID creatorId, @Param("contentId") UUID contentId);
 }

--- a/src/main/java/com/subcrii/subcrii/domain/content/service/ContentService.java
+++ b/src/main/java/com/subcrii/subcrii/domain/content/service/ContentService.java
@@ -1,5 +1,6 @@
 package com.subcrii.subcrii.domain.content.service;
 
+import com.subcrii.subcrii.domain.content.dto.ContentDetailResponse;
 import com.subcrii.subcrii.domain.content.dto.ContentListResponse;
 import com.subcrii.subcrii.domain.content.repository.ContentRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +19,12 @@ public class ContentService {
     @Transactional(readOnly = true)
     public Page<ContentListResponse> getContentList(UUID creatorId, Pageable pageable) {
         return contentRepository.findContentListByCreatorId(creatorId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public ContentDetailResponse getContentDetail(UUID creatorId, UUID contentId) {
+        //todo : 구독자만 조회 가능하도록
+        return contentRepository.findDetailByCreatorIdAndContentId(creatorId, contentId)
+                .orElseThrow(()-> new IllegalArgumentException("Content not found"));
     }
 }


### PR DESCRIPTION
## Issue Number

- #19 

## 작업 내용

- 구독한 크리에이터의 컨텐츠 내용을 조회할 수 있다.
- 로그인 기능 구현되면 해당 크리에이터를 구독한 유저만 조회할 수 있도록 수정

## To Reviewers
<img width="927" height="503" alt="image" src="https://github.com/user-attachments/assets/4a205510-de91-4bc3-9e15-0b359f0773aa" />


## 관련 이슈

Closes #19 
