### PR TITLE
Feat:  구독 생성 및 구독 취소 API 구현

### DIFF
--- a/src/main/java/com/subcrii/subcrii/domain/content/repository/ContentRepository.java
+++ b/src/main/java/com/subcrii/subcrii/domain/content/repository/ContentRepository.java
@@ -8,10 +8,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 import java.util.UUID;
 
+@Repository
 public interface ContentRepository extends JpaRepository<Content, UUID> {
     @Query(value = """
                 select new com.subcrii.subcrii.domain.content.dto.ContentListResponse(

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/controller/SubscriptionController.java
@@ -1,0 +1,43 @@
+package com.subcrii.subcrii.domain.subscription.controller;
+
+import com.subcrii.subcrii.domain.subscription.dto.SubscriptionCancelResponse;
+import com.subcrii.subcrii.domain.subscription.dto.SubscriptionCreateResponse;
+import com.subcrii.subcrii.domain.subscription.entity.Subscription;
+import com.subcrii.subcrii.domain.subscription.service.SubscriptionService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/creators/{creatorId}/subscriptions")
+public class SubscriptionController {
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping
+    @Operation(summary = "구독하기", description = "유저가 크리에이터를 구독할 수 있습니다. (결제 전 status = PENDING)")
+    public ResponseEntity<SubscriptionCreateResponse> subscribe(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID creatorId
+    ) {
+        UUID memberId = UUID.fromString(userDetails.getUsername());
+        return ResponseEntity.ok(subscriptionService.subscribe(memberId, creatorId));
+    }
+
+    @DeleteMapping
+    @Operation(summary = "구독 취소", description = "유저가 크리에이터 구독을 취소할 수 있습니다. (status = CANCELED)")
+    public ResponseEntity<SubscriptionCancelResponse> cancel(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable UUID creatorId
+    ) {
+        UUID memberId = UUID.fromString(userDetails.getUsername());
+
+        Subscription canceled = subscriptionService.cancel(memberId, creatorId);
+        return ResponseEntity.ok(SubscriptionCancelResponse.from(canceled));
+    }
+}

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/dto/SubscriptionCancelResponse.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/dto/SubscriptionCancelResponse.java
@@ -1,0 +1,25 @@
+package com.subcrii.subcrii.domain.subscription.dto;
+
+import com.subcrii.subcrii.domain.subscription.entity.Subscription;
+import com.subcrii.subcrii.domain.subscription.entity.SubscriptionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class SubscriptionCancelResponse {
+    private UUID subscriptionId;
+    private SubscriptionStatus status;
+    private LocalDateTime canceledAt;
+
+    public static SubscriptionCancelResponse from(Subscription s) {
+        return new SubscriptionCancelResponse(
+                s.getId(),
+                s.getSubscriptionStatus(),
+                s.getCanceledAt()
+        );
+    }
+}

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/dto/SubscriptionCreateResponse.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/dto/SubscriptionCreateResponse.java
@@ -1,0 +1,25 @@
+package com.subcrii.subcrii.domain.subscription.dto;
+
+import com.subcrii.subcrii.domain.subscription.entity.Subscription;
+import com.subcrii.subcrii.domain.subscription.entity.SubscriptionStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@AllArgsConstructor
+public class SubscriptionCreateResponse {
+    private UUID subscriptionId;
+    private SubscriptionStatus status;
+    private LocalDateTime nextBillingAt;
+
+    public static SubscriptionCreateResponse from(Subscription s) {
+        return new SubscriptionCreateResponse(
+                s.getId(),
+                s.getSubscriptionStatus(),
+                s.getNextBillingAt()
+        );
+    }
+}

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/entity/Subscription.java
@@ -4,12 +4,18 @@ import com.subcrii.subcrii.domain.creator.entity.Creator;
 import com.subcrii.subcrii.domain.member.entity.Member;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 import java.util.UUID;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Subscription {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -37,4 +43,44 @@ public class Subscription {
 
     private LocalDateTime nextBillingAt;    // 다음 결제 예정일 (존재하지 않으면 그 달 마지막일로 대체)
     private LocalDateTime canceledAt;  // 구독 취소일
+
+    private Subscription(Creator creator, Member member, SubscriptionStatus subscriptionStatus,
+                         Integer billingDay, LocalDateTime nextBillingAt) {
+        if (creator == null || member == null) {
+            throw new IllegalArgumentException("creator/member는 필수");
+        }
+        this.creator = creator;
+        this.member = member;
+        this.subscriptionStatus = subscriptionStatus;
+        this.billingDay = billingDay;
+        this.nextBillingAt = nextBillingAt;
+    }
+
+    public static Subscription createSubscription(Creator creator, Member member, LocalDateTime now) {
+        if (now == null) now = LocalDateTime.now();
+
+        int billingDay = now.getDayOfMonth();
+        LocalDateTime nextBillingAt = computeNextBillingAt(now, billingDay);
+        return new Subscription(creator, member, SubscriptionStatus.PENDING, billingDay, nextBillingAt);
+    }
+
+    private static LocalDateTime computeNextBillingAt(LocalDateTime base, int billingDay) {
+        LocalDate baseDate = base.toLocalDate();
+        LocalDate nextMonth = baseDate.plusMonths(1).withDayOfMonth(1);
+
+        if (billingDay < 1 || billingDay > 31) {
+            throw new IllegalArgumentException("매월 청구일은 1~31일 사이여야 합니다.");
+        }
+
+        int lastDay = YearMonth.from(nextMonth).lengthOfMonth();
+        int day = Math.min(billingDay, lastDay);
+
+        return nextMonth.withDayOfMonth(day).atTime(base.toLocalTime());
+    }
+
+    public void cancel(LocalDateTime now) {
+        if (this.subscriptionStatus == SubscriptionStatus.CANCELED) return;
+        this.subscriptionStatus = SubscriptionStatus.CANCELED;
+        this.canceledAt = (now != null) ? now : LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/entity/SubscriptionStatus.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/entity/SubscriptionStatus.java
@@ -1,6 +1,7 @@
 package com.subcrii.subcrii.domain.subscription.entity;
 
 public enum SubscriptionStatus {
+    PENDING,    // 결제 전
     ACTIVE,     // 정상 구독
     CANCELED,   // 취소됨 (남은 기간 유지)
     EXPIRED     // 구독 종료 (기간 끝남)

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/repository/SubscriptionRepository.java
@@ -1,0 +1,26 @@
+package com.subcrii.subcrii.domain.subscription.repository;
+
+import com.subcrii.subcrii.domain.subscription.entity.Subscription;
+import com.subcrii.subcrii.domain.subscription.entity.SubscriptionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SubscriptionRepository extends JpaRepository<Subscription, UUID> {
+    boolean existsByMember_IdAndCreator_IdAndSubscriptionStatusIn(
+            UUID memberId,
+            UUID creatorId,
+            Collection<SubscriptionStatus> statuses
+    );
+
+    Optional<Subscription> findTopByMember_IdAndCreator_IdAndSubscriptionStatusInOrderByStartAtDesc(
+            UUID memberId,
+            UUID creatorId,
+            Collection<SubscriptionStatus> statuses
+    );
+
+}

--- a/src/main/java/com/subcrii/subcrii/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/subcrii/subcrii/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,63 @@
+package com.subcrii.subcrii.domain.subscription.service;
+
+import com.subcrii.subcrii.domain.creator.entity.Creator;
+import com.subcrii.subcrii.domain.creator.repository.CreatorRepository;
+import com.subcrii.subcrii.domain.member.entity.Member;
+import com.subcrii.subcrii.domain.member.repository.MemberRepository;
+import com.subcrii.subcrii.domain.subscription.dto.SubscriptionCreateResponse;
+import com.subcrii.subcrii.domain.subscription.entity.Subscription;
+import com.subcrii.subcrii.domain.subscription.entity.SubscriptionStatus;
+import com.subcrii.subcrii.domain.subscription.repository.SubscriptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SubscriptionService {
+    private final SubscriptionRepository subscriptionRepository;
+    private final MemberRepository memberRepository;
+    private final CreatorRepository creatorRepository;
+
+    @Transactional
+    public SubscriptionCreateResponse subscribe(UUID memberId, UUID creatorId) {
+        boolean alreadySubscribed = subscriptionRepository.existsByMember_IdAndCreator_IdAndSubscriptionStatusIn(
+                memberId,
+                creatorId,
+                List.of(SubscriptionStatus.PENDING, SubscriptionStatus.ACTIVE)
+        );
+        if (alreadySubscribed) {
+            throw new IllegalStateException("이미 구독중이거나 결제 대기 상태입니다.");
+        }
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다. : " + memberId));
+
+        Creator creator = creatorRepository.findById(creatorId)
+                .orElseThrow(() -> new IllegalArgumentException("크리에이터를 찾을 수 없습니다.: " + creatorId));
+
+        Subscription subscription = subscriptionRepository.save(
+                Subscription.createSubscription(creator, member, LocalDateTime.now())
+        );
+        return SubscriptionCreateResponse.from(subscription);
+    }
+
+    @Transactional
+    public Subscription cancel(UUID memberId, UUID creatorId) {
+        Subscription subscription = subscriptionRepository
+                .findTopByMember_IdAndCreator_IdAndSubscriptionStatusInOrderByStartAtDesc(
+                        memberId,
+                        creatorId,
+                        List.of(SubscriptionStatus.PENDING, SubscriptionStatus.ACTIVE)
+                )
+                .orElseThrow(() -> new IllegalArgumentException("구독 정보를 찾을 수 없습니다."));
+
+        subscription.cancel(LocalDateTime.now());
+        return subscription;
+    }
+
+}


### PR DESCRIPTION
## Issue Number

- #25 

## 작업 내용

- 구독 생성 및 구독 취소 api 구현
- 매월 청구일 (billingDay) 계산
  - 매월 청구일이 다음 월에 없으면 그 달의 마지막 날이 청구일
  ex) 청구일이 1월 31일이었다면 다음 청구일은 2월 28일
  청구일에는 31일이 저장되어 있으므로 그 다음 청구일은 3월 31일이 됨 
- 구독을 눌렀으나 결제 전에는 pending 상태
- 구독 상태가 pending 이나 active일 때 구독을 하면 예외 (이미 구독중)
- 구독 상태가 pending 이나 active일 때 구독 취소를 하면 구독 취소 처리됨

## To Reviewers

- 구독 생성
<img width="895" height="549" alt="image" src="https://github.com/user-attachments/assets/9adcbe0d-01cd-4830-96e1-8bc5e1fd6336" />

- 구독 취소
<img width="871" height="461" alt="image" src="https://github.com/user-attachments/assets/de53434b-759a-4299-87d6-92174bb9302c" />


## 관련 이슈

- Closes #25
